### PR TITLE
Error handling

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -54,9 +54,9 @@ func NewBuilder(c config) (*Bob, error) {
 	}, nil
 }
 
-func (b *Bob) Close() {
-	b.w.Close()
+func (b *Bob) Close() error {
 	close(b.done)
+	return b.w.Close()
 }
 
 func (b *Bob) Watch(path string) error {

--- a/builder_test.go
+++ b/builder_test.go
@@ -17,7 +17,8 @@ func TestClose(t *testing.T) {
 	b, err := NewBuilder(config{})
 	require.NoError(t, err)
 
-	b.Close()
+	err = b.Close()
+	assert.NoError(t, err)
 
 	_, ok := <-b.done
 	assert.False(t, ok, "channel 'done' was not closed")

--- a/vow/promise.go
+++ b/vow/promise.go
@@ -87,7 +87,8 @@ func (p *promise) kill() {
 	atomic.StoreInt32(p.killed, 1)
 	p.cmdMtx.Lock()
 	if p.cmd.Process != nil {
-		p.cmd.Process.Signal(syscall.SIGTERM)
+		// if we can't signal the process assume it has died
+		_ = p.cmd.Process.Signal(syscall.SIGTERM)
 	}
 	p.cmdMtx.Unlock()
 }

--- a/vow/promise.go
+++ b/vow/promise.go
@@ -75,7 +75,8 @@ func (p *promise) writeIfAlive(w io.Writer, b []byte) {
 	if p.isKilled() {
 		return
 	}
-	w.Write([]byte(b))
+	// ignoring error since there is not much we can do
+	_, _ = w.Write(b)
 }
 
 func (p *promise) isKilled() bool {


### PR DESCRIPTION
- Made Bob.Close() return the error that may be return from `fsnotify`. 
- Explicitly ignored errors
