### PR TITLE
parsing env vars in scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ directory that you want to watch.
 
 Here is a sample of a `.snag.yml` file:
 
-```yml
+```yaml
 script:
   - echo "hello world"
   - go test
@@ -85,6 +85,16 @@ option form the snag file if it is defined to false.
 
 **NOTE**: using the `-c` flag will skip reading a snag file even if it
 exists in the current working directory.
+
+### Environment Variables
+
+You can access your shell's environment variables by using `$$`.
+
+```yaml
+script:
+  - echo $$MY_VAR
+  - rm -rf $$OUTPUT_DIR
+```
 
 ## Caveats
 

--- a/builder.go
+++ b/builder.go
@@ -42,6 +42,11 @@ func NewBuilder(c config) (*Bob, error) {
 	cmds := make([][]string, len(c.Script))
 	for i, s := range c.Script {
 		cmds[i] = strings.Split(s, " ")
+
+		// check for environment variables inside script
+		if strings.Contains(s, "$$") {
+			replaceEnv(cmds[i])
+		}
 	}
 
 	return &Bob{
@@ -52,6 +57,16 @@ func NewBuilder(c config) (*Bob, error) {
 		ignoredItems: c.IgnoredItems,
 		verbose:      c.Verbose,
 	}, nil
+}
+
+func replaceEnv(cmds []string) {
+	for i, c := range cmds {
+		if !strings.HasPrefix(c, "$$") {
+			continue
+		}
+
+		cmds[i] = os.Getenv(strings.TrimPrefix(c, "$$"))
+	}
 }
 
 func (b *Bob) Close() error {

--- a/builder_test.go
+++ b/builder_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,6 +12,19 @@ func TestNewBuilder(t *testing.T) {
 	b, err := NewBuilder(config{})
 	assert.NoError(t, err)
 	assert.NotNil(t, b)
+}
+
+func TestNewBuilder_EnvScript(t *testing.T) {
+	testEnv := "foobar"
+	os.Setenv("TEST_ENV", testEnv)
+	b, err := NewBuilder(config{
+		Script: []string{"echo $$TEST_ENV"},
+	})
+	assert.NoError(t, err)
+	assert.NotNil(t, b)
+
+	require.Len(t, b.cmds, 1)
+	assert.Equal(t, testEnv, b.cmds[0][1])
 }
 
 func TestClose(t *testing.T) {


### PR DESCRIPTION
The code looks for env vars to start with '2729' instead of just a single '$' no matter the operating system.

resolves #42 

TODO:
- [x] Add documentation to README regarding parsing environment.
