### PR TITLE
Deprecate Script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 snag**
-tmp**
 
 *out

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 snag**
+tmp**
 
 *out

--- a/.snag.yml
+++ b/.snag.yml
@@ -5,7 +5,7 @@ ignore:
   - snag
   - snag.exe
 
-script:
+build:
   - go build
   - go vet
   - gofmt -l -s .

--- a/.snag.yml
+++ b/.snag.yml
@@ -4,9 +4,10 @@ ignore:
   - .git
   - snag
   - snag.exe
+  - "tmp**"
 
 build:
   - go build
   - go vet
   - gofmt -l -s .
-  - go test ./... -v -race
+  - go test ./... -v -test.short

--- a/.snag.yml
+++ b/.snag.yml
@@ -4,7 +4,6 @@ ignore:
   - .git
   - snag
   - snag.exe
-  - "tmp**"
 
 build:
   - go build

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ script:
   # vet out possible issues
   - go vet ./...
   # run tests
-  - go test ./...
+  - go test ./... -v -race
 
 after_success:
   - |

--- a/builder.go
+++ b/builder.go
@@ -27,6 +27,7 @@ type Bob struct {
 	watching map[string]struct{}
 	watchDir string
 
+	depWarning   string
 	cmds         [][]string
 	ignoredItems []string
 
@@ -54,6 +55,7 @@ func NewBuilder(c config) (*Bob, error) {
 		done:         make(chan struct{}),
 		watching:     map[string]struct{}{},
 		cmds:         cmds,
+		depWarning:   c.DepWarnning,
 		ignoredItems: c.IgnoredItems,
 		verbose:      c.Verbose,
 	}, nil
@@ -145,6 +147,10 @@ func (b *Bob) execute() {
 
 	clearBuffer()
 	b.mtx.Lock()
+
+	if len(b.depWarning) > 0 {
+		fmt.Printf("Deprecation Warnings!\n%s", b.depWarning)
+	}
 
 	// setup the first command
 	firstCmd := b.cmds[0]

--- a/builder.go
+++ b/builder.go
@@ -39,8 +39,8 @@ func NewBuilder(c config) (*Bob, error) {
 		return nil, err
 	}
 
-	cmds := make([][]string, len(c.Script))
-	for i, s := range c.Script {
+	cmds := make([][]string, len(c.Build))
+	for i, s := range c.Build {
 		cmds[i] = strings.Split(s, " ")
 
 		// check for environment variables inside script

--- a/builder_test.go
+++ b/builder_test.go
@@ -18,7 +18,7 @@ func TestNewBuilder_EnvScript(t *testing.T) {
 	testEnv := "foobar"
 	os.Setenv("TEST_ENV", testEnv)
 	b, err := NewBuilder(config{
-		Script: []string{"echo $$TEST_ENV"},
+		Build: []string{"echo $$TEST_ENV"},
 	})
 	assert.NoError(t, err)
 	assert.NotNil(t, b)

--- a/main.go
+++ b/main.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
+	"time"
 
 	"gopkg.in/yaml.v2"
 )
@@ -23,6 +25,7 @@ func (a *argSlice) Set(value string) error {
 
 type config struct {
 	Script       []string `yaml:"script"`
+	Build        []string `yaml:"build"`
 	IgnoredItems []string `yaml:"ignore"`
 	Verbose      bool     `yaml:"verbose"`
 }
@@ -51,27 +54,9 @@ func main() {
 		return
 	}
 
-	var c config
-	if len(cliCmds) > 0 {
-		c.Script = cliCmds
-	} else {
-		in, err := ioutil.ReadFile(".snag.yml")
-		if err != nil {
-			log.Fatal("Could not find '.snag.yml' in your current directory")
-		}
-
-		if err := yaml.Unmarshal(in, &c); err != nil {
-			log.Fatalf("Could not parse yml file. %s\n", err)
-		}
-
-	}
-
-	if len(c.Script) == 0 {
-		log.Fatal("You must specify at least 1 command.")
-	}
-
-	if verbose {
-		c.Verbose = verbose
+	c, err := parseConfig()
+	if err != nil {
+		log.Fatal(err)
 	}
 
 	b, err := NewBuilder(c)
@@ -86,4 +71,47 @@ func main() {
 	}
 
 	b.Watch(wd)
+}
+
+func parseConfig() (config, error) {
+	var c config
+
+	// if we have any cliCmds, set them to our build phase
+	c.Build = cliCmds
+
+	// if build phase is still empty try and find the snag.yml file
+	if len(c.Build) == 0 {
+		in, err := ioutil.ReadFile(".snag.yml")
+		if err != nil {
+			return c, errors.New("Could not find '.snag.yml' in your current directory")
+		}
+
+		if err := yaml.Unmarshal(in, &c); err != nil {
+			return c, fmt.Errorf("Could not parse yml file. %s\n", err)
+		}
+	}
+
+	// if both script and build are specified
+	// blow up and tell the user to use build
+	if len(c.Script) != 0 && len(c.Build) != 0 {
+		return c, errors.New("Cannot use 'script' and 'build' together. The 'script' tag is deprecated, please use 'build' instead")
+	}
+
+	// if script has something, tell the user it's deprecated
+	// and set whatever its contents are to build
+	if len(c.Script) != 0 {
+		fmt.Println("The use of 'script' in the yaml file has been deprecated and will be removed in the future.")
+		fmt.Println("Please start using 'build' instead.")
+		c.Build = c.Script
+		// give the user some time to read the message before everything starts
+		// and we clear the text
+		time.Sleep(5 * time.Second)
+	}
+
+	if len(c.Build) == 0 {
+		return c, errors.New("You must specify at least 1 command.")
+	}
+
+	c.Verbose = verbose || c.Verbose
+	return c, nil
 }

--- a/main.go
+++ b/main.go
@@ -7,7 +7,6 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"time"
 
 	"gopkg.in/yaml.v2"
 )
@@ -24,6 +23,7 @@ func (a *argSlice) Set(value string) error {
 }
 
 type config struct {
+	DepWarnning  string
 	Script       []string `yaml:"script"`
 	Build        []string `yaml:"build"`
 	IgnoredItems []string `yaml:"ignore"`
@@ -100,12 +100,8 @@ func parseConfig() (config, error) {
 	// if script has something, tell the user it's deprecated
 	// and set whatever its contents are to build
 	if len(c.Script) != 0 {
-		fmt.Println("The use of 'script' in the yaml file has been deprecated and will be removed in the future.")
-		fmt.Println("Please start using 'build' instead.")
+		c.DepWarnning += "*\tThe use of 'script' in the yaml file has been deprecated and will be removed in the future.\n\tPlease start using 'build' instead.\n\n"
 		c.Build = c.Script
-		// give the user some time to read the message before everything starts
-		// and we clear the text
-		time.Sleep(5 * time.Second)
 	}
 
 	if len(c.Build) == 0 {

--- a/main.go
+++ b/main.go
@@ -94,7 +94,7 @@ func parseConfig() (config, error) {
 	// if both script and build are specified
 	// blow up and tell the user to use build
 	if len(c.Script) != 0 && len(c.Build) != 0 {
-		return c, errors.New("Cannot use 'script' and 'build' together. The 'script' tag is deprecated, please use 'build' instead")
+		return c, errors.New("Cannot use 'script' and 'build' together. The 'script' tag is deprecated, please use 'build' instead.")
 	}
 
 	// if script has something, tell the user it's deprecated

--- a/main_test.go
+++ b/main_test.go
@@ -1,8 +1,8 @@
 package main
 
 import (
+	"io/ioutil"
 	"os"
-	"path"
 	"regexp"
 	"strconv"
 	"testing"
@@ -116,8 +116,7 @@ func tmpDirectory(t *testing.T) (string, string) {
 	wd, err := os.Getwd()
 	require.NoError(t, err, "could not get working directory")
 
-	tmpDir := path.Join(wd, "tmp", strconv.FormatInt(time.Now().UnixNano(), 10))
-	err = os.MkdirAll(tmpDir, 0700)
+	tmpDir, err := ioutil.TempDir("", strconv.FormatInt(time.Now().UnixNano(), 10))
 	require.NoError(t, err, "could not create tmp directory")
 	return wd, tmpDir
 }

--- a/main_test.go
+++ b/main_test.go
@@ -120,6 +120,7 @@ func tmpDirectory(t *testing.T) (string, string) {
 func writeSnagFile(t *testing.T, content string) {
 	f, err := os.Create(".snag.yml")
 	require.NoError(t, err, "could not create snag.yml")
+	defer f.Close()
 
 	_, err = f.WriteString(content)
 	require.NoError(t, err, "could not write content to snag.yml")

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"os"
+	"path"
+	"regexp"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseConfig_CliCmds(t *testing.T) {
+	args := []string{"foo", "bar"}
+	cliCmds = argSlice(args)
+	defer func() { cliCmds = nil }()
+
+	c, err := parseConfig()
+	require.NoError(t, err)
+	assert.Equal(t, args, c.Build)
+}
+
+func TestParseConfig_NoSnagFile(t *testing.T) {
+	wd, tmpDir := tmpDirectory(t)
+	defer os.RemoveAll(tmpDir)
+
+	chdir(t, tmpDir)
+	defer os.Chdir(wd)
+
+	_, err := parseConfig()
+	require.Error(t, err)
+	assert.Equal(t, "Could not find '.snag.yml' in your current directory", err.Error())
+}
+
+func TestParseConfig_FunkyYml(t *testing.T) {
+	wd, tmpDir := tmpDirectory(t)
+	defer os.RemoveAll(tmpDir)
+
+	chdir(t, tmpDir)
+	defer os.Chdir(wd)
+
+	writeSnagFile(t, "I like to thing I'm yaml")
+	_, err := parseConfig()
+	require.Error(t, err)
+	rx := regexp.MustCompile(`^Could not parse yml file\. .+`)
+	assert.Regexp(t, rx, err.Error())
+}
+
+func TestParseConfig_ScriptAndBuild(t *testing.T) {
+	wd, tmpDir := tmpDirectory(t)
+	defer os.RemoveAll(tmpDir)
+
+	chdir(t, tmpDir)
+	defer os.Chdir(wd)
+
+	writeSnagFile(t, "verbose: true\nbuild:\n  - echo 'hello'\nscript:\n  - echo 'hello'")
+	_, err := parseConfig()
+	require.Error(t, err)
+	assert.Equal(t, "Cannot use 'script' and 'build' together. The 'script' tag is deprecated, please use 'build' instead.", err.Error())
+}
+
+func TestParseConfig_Script(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
+	wd, tmpDir := tmpDirectory(t)
+	defer os.RemoveAll(tmpDir)
+
+	chdir(t, tmpDir)
+	defer os.Chdir(wd)
+
+	writeSnagFile(t, "verbose: true\nscript:\n  - echo 'hello'")
+	c, err := parseConfig()
+	require.NoError(t, err)
+	assert.Equal(t, []string{"echo 'hello'"}, c.Build)
+}
+
+func TestParseConfig_EmptyBuild(t *testing.T) {
+	wd, tmpDir := tmpDirectory(t)
+	defer os.RemoveAll(tmpDir)
+
+	chdir(t, tmpDir)
+	defer os.Chdir(wd)
+
+	writeSnagFile(t, "verbose: true")
+	_, err := parseConfig()
+	require.Error(t, err)
+	assert.Equal(t, "You must specify at least 1 command.", err.Error())
+}
+
+func TestParseConfig_Verbose(t *testing.T) {
+	verbose = true
+	defer func() { verbose = false }()
+
+	wd, tmpDir := tmpDirectory(t)
+	defer os.RemoveAll(tmpDir)
+
+	chdir(t, tmpDir)
+	defer os.Chdir(wd)
+
+	writeSnagFile(t, "build:\n  - echo 'hello'")
+	c, err := parseConfig()
+	require.NoError(t, err)
+	assert.True(t, c.Verbose, "verbosity was not set correctly")
+}
+
+func chdir(t *testing.T, path string) {
+	err := os.Chdir(path)
+	require.NoError(t, err, "could not change directories")
+}
+
+func tmpDirectory(t *testing.T) (string, string) {
+	wd, err := os.Getwd()
+	require.NoError(t, err, "could not get working directory")
+
+	tmpDir := path.Join(wd, "tmp", strconv.FormatInt(time.Now().UnixNano(), 10))
+	err = os.MkdirAll(tmpDir, 0700)
+	require.NoError(t, err, "could not create tmp directory")
+	return wd, tmpDir
+}
+
+func writeSnagFile(t *testing.T, content string) {
+	f, err := os.Create(".snag.yml")
+	require.NoError(t, err, "could not create snag.yml")
+
+	_, err = f.WriteString(content)
+	require.NoError(t, err, "could not write content to snag.yml")
+}

--- a/main_test.go
+++ b/main_test.go
@@ -62,10 +62,6 @@ func TestParseConfig_ScriptAndBuild(t *testing.T) {
 }
 
 func TestParseConfig_Script(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping test in short mode.")
-	}
-
 	wd, tmpDir := tmpDirectory(t)
 	defer os.RemoveAll(tmpDir)
 


### PR DESCRIPTION
PR deprecates the `script` tag on the `.snag.yml` as per conversations on #48 . Also added some tests on the parsing side of things.
