### PR TITLE
Adding parallel runners

### DIFF
--- a/builder_test.go
+++ b/builder_test.go
@@ -23,8 +23,8 @@ func TestNewBuilder_EnvScript(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, b)
 
-	require.Len(t, b.cmds, 1)
-	assert.Equal(t, testEnv, b.cmds[0][1])
+	require.Len(t, b.buildCmds, 1)
+	assert.Equal(t, testEnv, b.buildCmds[0][1])
 }
 
 func TestClose(t *testing.T) {

--- a/builder_test.go
+++ b/builder_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,22 +10,27 @@ import (
 )
 
 func TestNewBuilder(t *testing.T) {
-	b, err := NewBuilder(config{})
-	assert.NoError(t, err)
-	assert.NotNil(t, b)
-}
-
-func TestNewBuilder_EnvScript(t *testing.T) {
 	testEnv := "foobar"
 	os.Setenv("TEST_ENV", testEnv)
-	b, err := NewBuilder(config{
-		Build: []string{"echo $$TEST_ENV"},
-	})
+	c := config{
+		Build:        []string{"echo Hello World", "echo $$TEST_ENV"},
+		Run:          []string{"echo async here"},
+		IgnoredItems: []string{"foo", "bar"},
+		Verbose:      true,
+	}
+	b, err := NewBuilder(c)
 	assert.NoError(t, err)
 	assert.NotNil(t, b)
 
-	require.Len(t, b.buildCmds, 1)
-	assert.Equal(t, testEnv, b.buildCmds[0][1])
+	require.Len(t, b.buildCmds, 2)
+	assert.Equal(t, c.Build[0], strings.Join(b.buildCmds[0], " "))
+	assert.Equal(t, testEnv, b.buildCmds[1][1])
+
+	require.Len(t, b.runCmds, 1)
+	assert.Equal(t, c.Run[0], strings.Join(b.runCmds[0], " "))
+
+	assert.Equal(t, c.Verbose, b.verbose)
+	assert.Equal(t, c.IgnoredItems, b.ignoredItems)
 }
 
 func TestClose(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ type config struct {
 	DepWarnning  string
 	Script       []string `yaml:"script"`
 	Build        []string `yaml:"build"`
+	Run          []string `yaml:"run"`
 	IgnoredItems []string `yaml:"ignore"`
 	Verbose      bool     `yaml:"verbose"`
 }

--- a/vow/promise.go
+++ b/vow/promise.go
@@ -68,8 +68,8 @@ func (p *promise) Run(w io.Writer, verbose bool) (err error) {
 
 	// if the process is async we don't need to do anything else
 	if p.async {
-		fmt.Println(" process id: ", p.cmd.Process.Pid)
 		go p.fowardOutput(p.cmd.Process.Pid, w, &buf)
+		go p.cmd.Wait()
 		return nil
 	}
 

--- a/vow/promise.go
+++ b/vow/promise.go
@@ -116,7 +116,9 @@ func (p *promise) Run(w io.Writer, verbose bool) (err error) {
 }
 
 func (p *promise) wait(w io.Writer, verbose bool, buf *syncBuffer) error {
+	p.cmdMtx.Lock()
 	err := p.cmd.Wait()
+	p.cmdMtx.Unlock()
 
 	status := statusPassed
 	if err != nil {

--- a/vow/promise.go
+++ b/vow/promise.go
@@ -21,6 +21,44 @@ var (
 	statusInProgress = "|" + yellow("In Progress") + "|"
 )
 
+type syncBuffer struct {
+	sync.RWMutex
+
+	buf *bytes.Buffer
+}
+
+func newSyncBuffer() *syncBuffer {
+	return &syncBuffer{buf: bytes.NewBuffer([]byte{})}
+}
+
+func (sb *syncBuffer) Write(p []byte) (int, error) {
+	sb.Lock()
+	n, err := sb.buf.Write(p)
+	sb.Unlock()
+	return n, err
+}
+
+func (sb *syncBuffer) Read(p []byte) (int, error) {
+	sb.RLock()
+	n, err := sb.buf.Read(p)
+	sb.RUnlock()
+	return n, err
+}
+
+func (sb *syncBuffer) Next(n int) []byte {
+	sb.RLock()
+	b := sb.buf.Next(n)
+	sb.RUnlock()
+	return b
+}
+
+func (sb *syncBuffer) Bytes() []byte {
+	sb.RLock()
+	b := sb.buf.Bytes()
+	sb.RUnlock()
+	return b
+}
+
 type promise struct {
 	cmdMtx sync.Mutex
 	cmd    *exec.Cmd
@@ -46,9 +84,9 @@ func (p *promise) Run(w io.Writer, verbose bool) (err error) {
 		return errKilled
 	}
 
-	var buf bytes.Buffer
-	p.cmd.Stdout = &buf
-	p.cmd.Stderr = &buf
+	buf := newSyncBuffer()
+	p.cmd.Stdout = buf
+	p.cmd.Stderr = buf
 
 	fmt.Fprintf(
 		w,
@@ -68,8 +106,7 @@ func (p *promise) Run(w io.Writer, verbose bool) (err error) {
 
 	// if the process is async we don't need to do anything else
 	if p.async {
-		go p.fowardOutput(p.cmd.Process.Pid, w, &buf)
-		go p.cmd.Wait()
+		go p.fowardOutput(p.cmd.Process.Pid, w, buf)
 		return nil
 	}
 
@@ -87,7 +124,7 @@ func (p *promise) Run(w io.Writer, verbose bool) (err error) {
 	return err
 }
 
-func (p *promise) fowardOutput(pid int, w io.Writer, buf *bytes.Buffer) {
+func (p *promise) fowardOutput(pid int, w io.Writer, buf *syncBuffer) {
 	prefix := []byte(fmt.Sprintf("pid %d : ", pid))
 	for t := time.Tick(time.Second); !p.isKilled(); <-t {
 		b := buf.Next(1024)

--- a/vow/to.go
+++ b/vow/to.go
@@ -31,6 +31,11 @@ func (vow *Vow) Then(name string, args ...string) *Vow {
 	return vow
 }
 
+func (vow *Vow) ThenAsync(name string, args ...string) *Vow {
+	vow.cmds = append(vow.cmds, newAsyncPromise(name, args...))
+	return vow
+}
+
 // Stop terminates the active command and stops the execution of any future commands
 func (vow *Vow) Stop() {
 	atomic.StoreInt32(vow.canceled, 1)

--- a/vow/to_test.go
+++ b/vow/to_test.go
@@ -78,9 +78,11 @@ func TestStopAsync(t *testing.T) {
 	<-time.After(10 * time.Millisecond)
 
 	vow.Stop()
-	for _, cmd := range vow.cmds {
-		cmd.cmd.Wait()
-		assert.True(t, cmd.cmd.ProcessState.Exited())
+	for _, p := range vow.cmds {
+		p.cmdMtx.Lock()
+		p.cmd.Wait()
+		assert.True(t, p.cmd.ProcessState.Exited())
+		p.cmdMtx.Unlock()
 	}
 }
 

--- a/vow/to_test.go
+++ b/vow/to_test.go
@@ -79,6 +79,7 @@ func TestStopAsync(t *testing.T) {
 
 	vow.Stop()
 	for _, cmd := range vow.cmds {
+		cmd.cmd.Wait()
 		assert.True(t, cmd.cmd.ProcessState.Exited())
 	}
 }


### PR DESCRIPTION
Closes #48

The snag.yml now accepts a 'Runners' tag. This tag represents a group
of commands that are meant to be run in parallel after the build stage.

Each process will be given a chance to start and will then get backgrounded
to allow other processes to run. The output of each command is streamed to
stdout prefix with the pid of the logging command
