### PR TITLE
POC for github.com/rjeczalik/notify

### DIFF
--- a/builder_test.go
+++ b/builder_test.go
@@ -37,8 +37,7 @@ func TestClose(t *testing.T) {
 	b, err := NewBuilder(config{})
 	require.NoError(t, err)
 
-	err = b.Close()
-	assert.NoError(t, err)
+	b.Close()
 
 	_, ok := <-b.done
 	assert.False(t, ok, "channel 'done' was not closed")


### PR DESCRIPTION
This package natively supports FSEvent which allows watching a large amount of files/directories. It also supports fs watchers for other platforms which may come in handy.

I'd like to test this out for a bit before merging. We still need to test this in Windows/Linux and see how it behaves at least on those OS. 

So far on OSX it has performed better than with `fsnotify` which threw the too many files opened. 
