### PR TITLE
Parsing string args correctly

### DIFF
--- a/builder_test.go
+++ b/builder_test.go
@@ -33,6 +33,35 @@ func TestNewBuilder(t *testing.T) {
 	assert.Equal(t, c.IgnoredItems, b.ignoredItems)
 }
 
+func TestNewBuilder_CmdWithQuotes(t *testing.T) {
+	c := config{
+		Build: []string{
+			`echo "hello world" foo`,
+			`echo "ga ga oh la la`,
+			`echo "ga" "foo"`,
+			`echo -c 'foo "bar"'`,
+		},
+	}
+
+	b, err := NewBuilder(c)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "echo", b.buildCmds[0][0])
+	assert.Equal(t, `"hello world"`, b.buildCmds[0][1])
+	assert.Equal(t, "foo", b.buildCmds[0][2])
+
+	assert.Equal(t, "echo", b.buildCmds[1][0])
+	assert.Equal(t, `"ga ga oh la la`, b.buildCmds[1][1])
+
+	assert.Equal(t, "echo", b.buildCmds[2][0])
+	assert.Equal(t, `"ga"`, b.buildCmds[2][1])
+	assert.Equal(t, `"foo"`, b.buildCmds[2][2])
+
+	assert.Equal(t, "echo", b.buildCmds[3][0])
+	assert.Equal(t, `-c`, b.buildCmds[3][1])
+	assert.Equal(t, `'foo "bar"'`, b.buildCmds[3][2])
+}
+
 func TestClose(t *testing.T) {
 	b, err := NewBuilder(config{})
 	require.NoError(t, err)


### PR DESCRIPTION
There was a bug in the code that cause commands that had quotes in them to not work as expected.
Commands are no longer split just on a whitespace. If an opening quote is found the split function
finds its ending quote and returns the entire chunk as one argument.
