### PR TITLE
Remove exchange dependency from watcher and builder

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/Tonkpils/snag/exchange"
 	"github.com/shiena/ansicolor"
 )
 
@@ -28,7 +27,6 @@ type Builder interface {
 }
 
 type CmdBuilder struct {
-	ex         exchange.SendListener
 	mtx        sync.RWMutex
 	depWarning string
 	buildCmds  [][]string
@@ -38,7 +36,7 @@ type CmdBuilder struct {
 	verbose bool
 }
 
-func New(ex exchange.SendListener, c Config) Builder {
+func New(c Config) Builder {
 	parseCmd := func(cmd string) (c []string) {
 		s := bufio.NewScanner(strings.NewReader(cmd))
 		s.Split(splitFunc)

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -21,7 +21,7 @@ func TestNewBuilder(t *testing.T) {
 		Run:     []string{"echo async here"},
 		Verbose: true,
 	}
-	b := New(nil, c)
+	b := New(c)
 	require.NotNil(t, b)
 
 	cb, ok := b.(*CmdBuilder)
@@ -78,7 +78,7 @@ func TestNewBuilder_CmdWithQuotes(t *testing.T) {
 			Run:   []string{test.Command},
 		}
 
-		b := New(nil, c)
+		b := New(c)
 		require.NotNil(t, b)
 
 		cb, ok := b.(*CmdBuilder)

--- a/main.go
+++ b/main.go
@@ -43,6 +43,7 @@ func main() {
 		log.Fatal(err)
 	}
 
+	rebuild := "rebuild"
 	ex := exchange.New()
 
 	bc := builder.Config{
@@ -51,10 +52,10 @@ func main() {
 		DepWarning: c.DepWarnning,
 		Verbose:    c.Verbose,
 	}
-	b := builder.New(ex, bc)
-	ex.Listen("rebuild", b.Build)
+	b := builder.New(bc)
+	ex.Listen(rebuild, b.Build)
 
-	w, err := watcher.New(ex, c.IgnoredItems)
+	w, err := watcher.New(c.IgnoredItems)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -63,6 +64,12 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	go func(w *watcher.FSWatcher) {
+		for range w.Event {
+			ex.Send(rebuild, nil)
+		}
+	}(w)
 
 	w.Watch(wd)
 }


### PR DESCRIPTION
This is the outcome of our conversation. Pretty much the builder and watcher do not have the exchange as a dependency. One thing that bothered me after doing these changes was that the watcher still has this notion of when things should be triggered to build. I can't quite pin point what it is that bothers me about it but maybe if you take a look at it you'll find it.

In any case, let me know what you think and we can either scrap it or move forward with these changes. 
